### PR TITLE
Fix text

### DIFF
--- a/game/game.rs
+++ b/game/game.rs
@@ -45,6 +45,12 @@ unsafe fn handle_mouse(state: &mut State) {
 
 pub type GameFrame = unsafe fn(state: &mut State);
 
+macro_rules! cstr {
+    ($($arg: tt)*) => {
+        std::ffi::CString::new(format!($($arg)*)).unwrap()
+    }
+}
+
 #[no_mangle]
 pub unsafe fn game_frame(state: &mut State) {
     handle_keys(state);
@@ -63,14 +69,14 @@ pub unsafe fn game_frame(state: &mut State) {
             x = state.rect.x.round(),
             y = state.rect.y.round()
         };
-        DrawText(rect_pos, 10, 10, 20, RAYWHITE);
+        DrawText(rect_pos.as_ptr(), 10, 10, 20, RAYWHITE);
 
         let mouse_pos = cstr!{
             "mouse: [{x}, {y}]",
             x = state.mouse_pos.x.round(),
             y = state.mouse_pos.y.round()
         };
-        DrawText(mouse_pos, 10, 30, 20, RAYWHITE);
+        DrawText(mouse_pos.as_ptr(), 10, 30, 20, RAYWHITE);
 
         DrawCircle(state.mouse_pos.x as i32, state.mouse_pos.y as i32, 10.0, RAYWHITE);
     } EndDrawing();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ const GAME_PATH: &str = if cfg!(target_os = "linux") {
 } else if cfg!(target_os = "windows") {
     ".\\target\\debug\\libgame.dll"
 } else {
-    "./target/debug/libgame.dylib"
+    "./target/debug/deps/libgame.dylib"
 };
 
 #[inline]


### PR DESCRIPTION
Fixes #2

The patched `cstr!` should probably migrate to `raylib_wasm`, but for now it makes this bit work.

Also, since `93e829f4` changed crate-type to `cdylib` the path of libgame.dylib changed, at least for me on mac, `rustc 1.84.1 (e71f9a9a9 2025-01-27)`, hence the GAME_PATH update. It might want changing on other platforms, but it's not something I can easily test.